### PR TITLE
fix: 프리미엄 상세 보기 중 AnswerType에 따른 객체 변환이 안되는 현상 수정

### DIFF
--- a/src/main/java/com/moyeoit/domain/review/controller/response/AnswerResponse.java
+++ b/src/main/java/com/moyeoit/domain/review/controller/response/AnswerResponse.java
@@ -1,0 +1,7 @@
+package com.moyeoit.domain.review.controller.response;
+
+
+public interface AnswerResponse {
+    
+
+}

--- a/src/main/java/com/moyeoit/domain/review/controller/response/MultipleChoiceAnswerResponse.java
+++ b/src/main/java/com/moyeoit/domain/review/controller/response/MultipleChoiceAnswerResponse.java
@@ -1,0 +1,38 @@
+package com.moyeoit.domain.review.controller.response;
+
+import com.moyeoit.domain.app_user.service.dto.AppUserDto;
+import com.moyeoit.domain.review.domain.PremiumReviewDetail;
+import com.moyeoit.domain.review.domain.enums.AnswerType;
+import java.util.Arrays;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MultipleChoiceAnswerResponse implements AnswerResponse {
+
+    private Long id;
+    private QuestionResponse question;
+    private AppUserDto userDto;
+    private List<Integer> value;
+    private AnswerType answerType;
+
+    public static MultipleChoiceAnswerResponse from(PremiumReviewDetail detail) {
+        return new MultipleChoiceAnswerResponse(
+                detail.getId(),
+                QuestionResponse.from(detail.getQuestion()),
+                AppUserDto.of(detail.getAppUser()),
+                Arrays.stream(detail.getValue().split(","))
+                        .map(Integer::parseInt)
+                        .toList(),
+                detail.getAnswerType()
+        );
+    }
+
+
+}

--- a/src/main/java/com/moyeoit/domain/review/controller/response/PremiumReviewResponse.java
+++ b/src/main/java/com/moyeoit/domain/review/controller/response/PremiumReviewResponse.java
@@ -30,9 +30,9 @@ public class PremiumReviewResponse {
     private ReviewCategory reviewCategory;
     private LocalDateTime createDazte;
     private LocalDateTime updateDate;
-    private List<PremiumReviewDetailResponse> details;
+    private List<AnswerResponse> details;
 
-    public static PremiumReviewResponse from(PremiumReview review) {
+    public static PremiumReviewResponse from(PremiumReview review, List<AnswerResponse> answerResponses) {
         List<PremiumReviewDetailResponse> premiumReviewDetailResponses = review.getPremiumReviewDetails().stream()
                 .map(PremiumReviewDetailResponse::from)
                 .toList();
@@ -48,11 +48,8 @@ public class PremiumReviewResponse {
                 review.getReviewCategory(),
                 review.getCreateDate(),
                 review.getUpdateDate(),
-                premiumReviewDetailResponses
+                answerResponses
         );
     }
-
-    // TODO details
-
 
 }

--- a/src/main/java/com/moyeoit/domain/review/controller/response/SingleChoiceAnswerResponse.java
+++ b/src/main/java/com/moyeoit/domain/review/controller/response/SingleChoiceAnswerResponse.java
@@ -1,0 +1,32 @@
+package com.moyeoit.domain.review.controller.response;
+
+import com.moyeoit.domain.app_user.service.dto.AppUserDto;
+import com.moyeoit.domain.review.domain.PremiumReviewDetail;
+import com.moyeoit.domain.review.domain.enums.AnswerType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SingleChoiceAnswerResponse implements AnswerResponse {
+
+    private Long id;
+    private QuestionResponse question;
+    private AppUserDto userDto;
+    private Integer value;
+    private AnswerType answerType;
+
+    public static SingleChoiceAnswerResponse from(PremiumReviewDetail detail) {
+        return new SingleChoiceAnswerResponse(detail.getId(),
+                QuestionResponse.from(detail.getQuestion()),
+                AppUserDto.of(detail.getAppUser()),
+                Integer.valueOf(detail.getValue()),
+                detail.getAnswerType()
+        );
+    }
+
+}

--- a/src/main/java/com/moyeoit/domain/review/controller/response/SubjectiveAnswerResponse.java
+++ b/src/main/java/com/moyeoit/domain/review/controller/response/SubjectiveAnswerResponse.java
@@ -1,0 +1,33 @@
+package com.moyeoit.domain.review.controller.response;
+
+import com.moyeoit.domain.app_user.service.dto.AppUserDto;
+import com.moyeoit.domain.review.domain.PremiumReviewDetail;
+import com.moyeoit.domain.review.domain.enums.AnswerType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SubjectiveAnswerResponse implements AnswerResponse {
+
+    private Long id;
+    private QuestionResponse question;
+    private AppUserDto userDto;
+    private String value;
+    private AnswerType answerType;
+
+    public static SubjectiveAnswerResponse from(PremiumReviewDetail detail) {
+        return new SubjectiveAnswerResponse(
+                detail.getId(),
+                QuestionResponse.from(detail.getQuestion()),
+                AppUserDto.of(detail.getAppUser()),
+                detail.getValue(),
+                detail.getAnswerType()
+        );
+    }
+
+}

--- a/src/main/java/com/moyeoit/domain/review/repository/QuestionRepository.java
+++ b/src/main/java/com/moyeoit/domain/review/repository/QuestionRepository.java
@@ -21,7 +21,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
             JOIN FETCH q.questionElements qe WHERE q.id IN :questionIds
             ORDER BY qe.sequence
             """)
-    Optional<Question> findByIdsWithQuestionElements(@Param("questionIds") List<Long> questionIds);
+    List<Question> findByIdsWithQuestionElements(@Param("questionIds") List<Long> questionIds);
 
 
 }

--- a/src/main/java/com/moyeoit/domain/review/service/PremiumReviewService.java
+++ b/src/main/java/com/moyeoit/domain/review/service/PremiumReviewService.java
@@ -11,7 +11,11 @@ import com.moyeoit.domain.review.controller.request.answer.AnswerRequest;
 import com.moyeoit.domain.review.controller.request.answer.MultipleChoiceAnswer;
 import com.moyeoit.domain.review.controller.request.answer.SingleChoiceAnswer;
 import com.moyeoit.domain.review.controller.request.answer.SubjectiveAnswer;
+import com.moyeoit.domain.review.controller.response.AnswerResponse;
+import com.moyeoit.domain.review.controller.response.MultipleChoiceAnswerResponse;
 import com.moyeoit.domain.review.controller.response.PremiumReviewResponse;
+import com.moyeoit.domain.review.controller.response.SingleChoiceAnswerResponse;
+import com.moyeoit.domain.review.controller.response.SubjectiveAnswerResponse;
 import com.moyeoit.domain.review.domain.PremiumReview;
 import com.moyeoit.domain.review.domain.PremiumReviewDetail;
 import com.moyeoit.domain.review.domain.Question;
@@ -63,7 +67,11 @@ public class PremiumReviewService {
             questionRepository.findByIdsWithQuestionElements(questionIds);
         }
 
-        return PremiumReviewResponse.from(premiumReview);
+        List<AnswerResponse> answers = premiumReview.getPremiumReviewDetails().stream()
+                .map(this::createAnswerResponse)
+                .toList();
+
+        return PremiumReviewResponse.from(premiumReview, answers);
     }
 
 
@@ -141,6 +149,22 @@ public class PremiumReviewService {
         }
 
         throw new AppException(ReviewErrorCode.NOT_FOUND_TYPE);
+    }
+
+    private AnswerResponse createAnswerResponse(PremiumReviewDetail detail) {
+        if (AnswerType.TEXT.equals(detail.getAnswerType())) {
+            return SubjectiveAnswerResponse.from(detail);
+        }
+
+        if (AnswerType.INTEGER.equals(detail.getAnswerType())) {
+            return SingleChoiceAnswerResponse.from(detail);
+        }
+
+        if (AnswerType.ARRAY_INTEGER.equals(detail.getAnswerType())) {
+            return MultipleChoiceAnswerResponse.from(detail);
+        }
+
+        throw new AppException(ReviewErrorCode.NOT_FOUND);
     }
 
 }


### PR DESCRIPTION
## What is this PR? :mag:
- 프리미엄 상세 보기 중 AnswerType에 따른 객체 변환이 안되는 현상 수정
    - PremiumReviewResponse의 detail 정보들을 AnswerResponse 인터페이스와 SubjectiveAnswerResponse, MultipleChoiceAnswerResponse, SingleChoiceAnswerResponse 로 구현하여 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Premium review responses now include structured answers with support for text, single-choice, and multiple-choice formats.
  - Each answer includes its question, respondent info, value, and type for clearer display and processing.

- Refactor
  - Unified answer representations under a common response contract to simplify client handling.
  - Service logic now assembles and returns a typed list of answers within the premium review response.
  - Question retrieval by multiple IDs now returns a list, improving handling of multi-question scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->